### PR TITLE
Application adapter fix [OSF-6698]

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,5 +1,19 @@
 import OsfAdapter from './osf-adapter';
 
-export default OsfAdapter.extend({
-    namespace: ''
+export default DS.JSONAPIAdapter.extend({
+    host: 'http://localhost:8000',
+    buildURL(modelName, id, snapshot, requestType) {
+        // Fix issue where CORS request failed on 301s: Ember does not seem to append trailing
+        // slash to URLs for single documents, but DRF redirects to force a trailing slash
+        var url = this._super(...arguments);
+        if (requestType === 'deleteRecord' || requestType === 'updateRecord' || requestType === 'findRecord') {
+            if (snapshot.record.get('links.self')) {
+                url = snapshot.record.get('links.self');
+            }
+        }
+        if (url.lastIndexOf('/') !== url.length - 1) {
+            url += '/';
+        }
+        return url;
+    },
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,5 +1,4 @@
-import OsfAdapter from './osf-adapter';
-
+import DS from 'ember-data';
 export default DS.JSONAPIAdapter.extend({
     host: 'http://localhost:8000',
     buildURL(modelName, id, snapshot, requestType) {
@@ -16,4 +15,15 @@ export default DS.JSONAPIAdapter.extend({
         }
         return url;
     },
+    ajax: function(url, method, hash) {
+		hash.crossDomain = true;
+		hash.xhrFields = {withCredentials: true};
+		return this._super(url, method, hash);
+  	},
+  	headers: Ember.computed(function() {
+	    return {
+	      "X-CSRFToken": Ember.get(document.cookie.match(/csrftoken\=([^;]*)/), "1")
+	    };
+  	}).volatile()
+
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -21,8 +21,16 @@ export default DS.JSONAPIAdapter.extend({
 		return this._super(url, method, hash);
   	},
   	headers: Ember.computed(function() {
+  		var csrftoken = ""
+  		try {
+  			var csrftoken = Ember.get(document.cookie.match(/csrftoken\=([^;]*)/), "1")
+  		} catch(e){
+  			console.log(e)
+  			console.log('no csrftoken present')
+  		}
+
 	    return {
-	      "X-CSRFToken": Ember.get(document.cookie.match(/csrftoken\=([^;]*)/), "1")
+	   		"X-CSRFToken": csrftoken
 	    };
   	}).volatile()
 


### PR DESCRIPTION
Switches to using JSONAPIAdapter instead of OsfAdapter. Since we are not making requests from ember to OSF directly, there is no need to use OsfAdapter. Fixes CSRF issues by placing CSRF token in header.
