### PR TITLE
Removing Horizontal Scroll

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -51,7 +51,6 @@ p
 
 .osf-light-background /* standard background */
 {
-  padding: 0;
   background-image: url("/assets/bg6.jpg");
   background-position: center;
   background-size: cover;

--- a/app/templates/components/meetings-navbar.hbs
+++ b/app/templates/components/meetings-navbar.hbs
@@ -13,8 +13,8 @@
                         <span rel="tooltip" data-placement="bottom" title="Search OSF" class="fa fa-search fa-lg fa-inverse" ></span>
                     </a>
                 </span>
-                <a class="navbar-brand hidden-sm hidden-xs" href="/"><span class="osf-navbar-logo" width="27"></span> Open Science Framework | Meetings</a>
-                <a class="navbar-brand visible-sm visible-xs" href="/"><span class="osf-navbar-logo" width="27"></span> Meetings</a>
+                <a class="navbar-brand hidden-sm hidden-xs" href="/"><span class="osf-navbar-logo" width="27"></span> OSF | Meetings</a>
+                <a class="navbar-brand visible-sm visible-xs" href="/"><span class="osf-navbar-logo" width="27"></span> OSF</a>
             </div>
             <div id="navbar" class="navbar-collapse collapse navbar-right">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
There was a lingering style creating room to horizontal scroll, this caused more notable issues on mobile viewports. This PR also changes the navbar headers so they are more collapsible, the previous title was a bit long so medium sized viewports would break down to a huge navbar before making it to mobile size.
