### PR TITLE
Make node public instead of private upon creation [OSF-6938]

### DIFF
--- a/meetings/submissions/views.py
+++ b/meetings/submissions/views.py
@@ -76,7 +76,8 @@ class SubmissionViewSet(viewsets.ModelViewSet):
                     'attributes': {
                         'category': 'project',
                         'description': request.data['description'],
-                        'title': request.data['title']
+                        'title': request.data['title'],
+                        'public': True
                     },
                     'type': 'nodes'
                 }


### PR DESCRIPTION
Currently nodes are being created as private. These nodes should be public so that they can be viewed by other conference participants.
