### PR TITLE
Create conference and transition to it when no logo [OSF-6939]

### DIFF
--- a/app/routes/conference/new.js
+++ b/app/routes/conference/new.js
@@ -25,8 +25,13 @@ export default Ember.Route.extend({
             });
         },
         saveConference(newConference, drop, resolve) {
-            newConference.save().then(() => {
-                resolve();
+            var router = this;
+            newConference.save().then((conf) => {
+                if(resolve){
+                    resolve();
+                } else{
+                    router.transitionTo('conference.index', conf.get('id'));
+                }
             });
         },
         success(dropZone, file, successData) {


### PR DESCRIPTION
Currently you can't submit a conference without a logo. This PR fixes that bug.
