### PR TITLE
Remove submission from store and transition on cancel [OSF-6941]

### DIFF
--- a/app/routes/conference/submission.js
+++ b/app/routes/conference/submission.js
@@ -25,6 +25,12 @@ export default Ember.Route.extend({
                     });      
                 });                     
         },
+        cancelSubmission() {
+            var sub_to_cancel = this.currentModel;
+            var conf = sub_to_cancel.get('conference');
+            sub_to_cancel.unloadRecord();
+            this.transitionTo('conference.index', conf.get('id'));
+        },
         preUpload(drop){
             drop.options.method = 'PUT';
         },


### PR DESCRIPTION
Currently, the cancel submission button does not work.

This PR makes it so that when you hit cancel, it removes the submission from store and transitions back to the conference.
