### PR TITLE
Redirect after login fix [OSF-6931]

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -6,6 +6,9 @@ default Ember.Route.extend({
         logout: function() {
             this.transitionTo('logout');
         },
+        login: function() {
+            this.transitionTo('login');
+        },
         filter(params) {
             this.transitionTo('index', {
                 queryParams: {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -6,10 +6,6 @@ default Ember.Route.extend({
         logout: function() {
             this.transitionTo('logout');
         },
-        login: function() {
-            document.cookie = "redirectURL=" + window.location.href;
-            this.transitionTo('login');
-        },
         filter(params) {
             this.transitionTo('index', {
                 queryParams: {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -24,31 +24,6 @@ export default Ember.Route.extend({
         });
         return foundConferences;
     },
-
-    //The beforeModel function here checks if the redirectURL is equal to something besides the index (current) route
-    //If it is equal to something else, it resets the redirectURL to the index route and transitions to the redirect URL
-
-    beforeModel: function() {
-        var redirectURL = this.getCookie('redirectURL');
-        if (redirectURL !== window.location.href) {
-            document.cookie = "redirectURL=" + window.location.href;
-            window.location = redirectURL;
-        }
-    },
-    getCookie: function(cname) {
-        var name = cname + "=";
-        var ca = document.cookie.split(';');
-        for(var i = 0; i <ca.length; i++) {
-            var c = ca[i];
-            while (c.charAt(0)===' ') {
-                c = c.substring(1);
-            }
-            if (c.indexOf(name) === 0) {
-                return c.substring(name.length,c.length);
-            }
-        }
-        return "";
-    },
     actions: {
         create() {
             this.transitionTo('conference.new').then(function(newRoute) {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -4,7 +4,14 @@ import config from '../config/environment';
 export
 default Ember.Route.extend({
     beforeModel: function() {
-        var nextQueryParam = "?next=" + window.location;
-        window.location = config.providers.osfMeetings.loginUrl + nextQueryParam;                      
+        var refererUrl = window.location.toString();
+        var nextQueryParam = '';
+        if (refererUrl.indexOf(config.providers.osfMeetings.loginUrl) == -1) {
+            // Make sure redirect url doesn't go back to login page
+            // and cause infinite loop
+            nextQueryParam = "?next=" + window.location;
+        }
+        
+        window.location = config.providers.osfMeetings.apiLoginUrl + nextQueryParam;                      
     }
 });

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -6,7 +6,7 @@ default Ember.Route.extend({
     beforeModel: function() {
         var refererUrl = window.location.toString();
         var nextQueryParam = '';
-        if (refererUrl.indexOf(config.providers.osfMeetings.loginUrl) == -1) {
+        if (refererUrl.indexOf(config.providers.osfMeetings.loginUrl) === -1) {
             // Make sure redirect url doesn't go back to login page
             // and cause infinite loop
             nextQueryParam = "?next=" + window.location;

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -3,7 +3,8 @@ import config from '../config/environment';
 
 export
 default Ember.Route.extend({
-    activate: function() {
-        window.location = config.providers.osfMeetings.apiUrl + "accounts/login/";
+    beforeModel: function() {
+        var nextQueryParam = "?next=" + window.location;
+        window.location = config.providers.osfMeetings.loginUrl + nextQueryParam;                      
     }
 });

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-	activate: function() {
+	beforeModel: function() {
         window.location = "http://localhost:8000/accounts/logout/";
     }
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,7 +38,8 @@ module.exports = function(environment) {
                 "currentUser": "http://localhost:8000/users/me/",
                 "uploadsUrl": "http://localhost:8000/uploads/",
                 "uploadMultiple": false,
-                "loginUrl" : "http://localhost:8000/accounts/login/"
+                "loginUrl": "http://localhost:4200/login",
+                "apiLoginUrl" : "http://localhost:8000/accounts/login/"
             },
             "osf": {
                 "host": "https://staging.osf.io/",

--- a/config/environment.js
+++ b/config/environment.js
@@ -37,7 +37,8 @@ module.exports = function(environment) {
                 "apiUrl": "http://localhost:8000/",
                 "currentUser": "http://localhost:8000/users/me/",
                 "uploadsUrl": "http://localhost:8000/uploads/",
-                "uploadMultiple": false
+                "uploadMultiple": false,
+                "loginUrl" : "http://localhost:8000/accounts/login/"
             },
             "osf": {
                 "host": "https://staging.osf.io/",

--- a/meetings/meetings/settings/defaults.py
+++ b/meetings/meetings/settings/defaults.py
@@ -232,7 +232,7 @@ HUMANS_GROUP_NAME = 'OSF_USERS'
 # Where users get redirected after logout (django allauth)
 ACCOUNT_LOGOUT_REDIRECT_URL = 'http://localhost:4200'
 
-OSF_MEETINGS_HOME_URL = 'http://localost:4200'
+OSF_MEETINGS_HOME_URL = 'http://localhost:4200'
 
 CLIENT_ID = ''
 CLIENT_SECRET = ''

--- a/meetings/meetings/settings/defaults.py
+++ b/meetings/meetings/settings/defaults.py
@@ -163,6 +163,10 @@ AUTHENTICATION_BACKENDS = (
 )
 
 
+# django allauth
+ADAPTER = "osf_oauth2_adapter.adapter.OsfMeetingsAdapter"
+ACCOUNT_ADAPTER = "osf_oauth2_adapter.adapter.OsfMeetingsAdapter"
+
 # django cors headers
 # http://blog.hugethoughts.com/allow-cors-specific-domain-django/
 CORS_ORIGIN_ALLOW_ALL = True
@@ -225,9 +229,10 @@ OSF_MEETINGS_API_URL = 'http://localhost:8000'
 DEFAULT_SCOPES = ['osf.full_write', ]
 HUMANS_GROUP_NAME = 'OSF_USERS'
 
-# Where users are redirected after login
-LOGIN_REDIRECT_URL = 'http://localhost:4200'
+# Where users get redirected after logout (django allauth)
 ACCOUNT_LOGOUT_REDIRECT_URL = 'http://localhost:4200'
+
+OSF_MEETINGS_HOME_URL = 'http://localost:4200'
 
 CLIENT_ID = ''
 CLIENT_SECRET = ''

--- a/meetings/meetings/settings/local-dist.py
+++ b/meetings/meetings/settings/local-dist.py
@@ -13,7 +13,7 @@ OSF_MEETINGS_API_URL = 'http://localhost:8000'
 DEFAULT_SCOPES = ['osf.full_write', ]
 HUMANS_GROUP_NAME = 'OSF_USERS'
 OSF_MEETINGS_API_URL = 'http://localhost:8000'
-OSF_MEETINGS_HOME_URL = 'http://localost:4200'
+OSF_MEETINGS_HOME_URL = 'http://localhost:4200'
 
 # Database
 # POSTGRES_NAME = ''

--- a/meetings/meetings/settings/local-dist.py
+++ b/meetings/meetings/settings/local-dist.py
@@ -13,6 +13,7 @@ OSF_MEETINGS_API_URL = 'http://localhost:8000'
 DEFAULT_SCOPES = ['osf.full_write', ]
 HUMANS_GROUP_NAME = 'OSF_USERS'
 OSF_MEETINGS_API_URL = 'http://localhost:8000'
+OSF_MEETINGS_HOME_URL = 'http://localost:4200'
 
 # Database
 # POSTGRES_NAME = ''

--- a/meetings/osf_oauth2_adapter/adapter.py
+++ b/meetings/osf_oauth2_adapter/adapter.py
@@ -1,0 +1,13 @@
+from allauth.account.adapter import DefaultAccountAdapter
+from django.conf import settings
+import urlparse
+
+class OsfMeetingsAdapter(DefaultAccountAdapter):
+    def get_login_redirect_url(self, request):
+        try:
+            refererUrl = request.environ['HTTP_REFERER']
+            nextUrl = urlparse.parse_qs(urlparse.urlparse(refererUrl).query)['next'][0]
+            return nextUrl
+        except KeyError, e:
+            return settings.OSF_MEETINGS_HOME_URL
+        

--- a/meetings/osf_oauth2_adapter/adapter.py
+++ b/meetings/osf_oauth2_adapter/adapter.py
@@ -2,12 +2,14 @@ from allauth.account.adapter import DefaultAccountAdapter
 from django.conf import settings
 import urlparse
 
+
 class OsfMeetingsAdapter(DefaultAccountAdapter):
+
     def get_login_redirect_url(self, request):
         try:
             refererUrl = request.environ['HTTP_REFERER']
-            nextUrl = urlparse.parse_qs(urlparse.urlparse(refererUrl).query)['next'][0]
+            nextUrl = urlparse.parse_qs(
+                urlparse.urlparse(refererUrl).query)['next'][0]
             return nextUrl
-        except KeyError, e:
+        except KeyError:
             return settings.OSF_MEETINGS_HOME_URL
-        


### PR DESCRIPTION
## Problem

Currently, after you login, it will redirect you back to the page you were last on before the login workflow. However, if you press the `OSF | Meetings` header, it doesn't take you back to the home page. Instead it takes you to the page you were on before the login workflow.
## Fix
- [x] Remove use of redirectURL cookie
- [x] Use query param ?next=url-to-go-back-to-after-login.com
