### PR TITLE
Clicking button twice to display a content [OSF-6923]

### DIFF
--- a/app/routes/conference/index.js
+++ b/app/routes/conference/index.js
@@ -1,11 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-    info: false,
-    init: function(){
-        this.controllerFor('index').set('info', false);
-        Ember.$('#submission-instructions').hide(); 
-    },
     model(params) {
         return Ember.RSVP.hash({
             conf : this.store.findRecord('conference', params.conference_id),
@@ -13,21 +8,5 @@ export default Ember.Route.extend({
                 conference: params.conference_id
             })
         });
-    },
-    isEqual: function(p1, p2) {
-        return (p1 === p2);
-    },
-    actions: {
-        //component reusable
-        toggleInfo() {
-            let curInfo = this.controllerFor('index').get('info');
-            if (curInfo === true){
-                Ember.$('#submission-instructions').hide(400);
-            }
-            else {
-                Ember.$('#submission-instructions').show(400);
-            }
-            this.controllerFor('index').set('info', !curInfo);
-        },
     }
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -97,19 +97,6 @@ export default Ember.Route.extend({
                     p: 1
                 }
             });
-        },
-        toggleInfo() {
-            //this needs fixing
-            //most likely will need to be a component
-            let curInfo = this.controllerFor('index').get('info');
-            console.log(curInfo);
-            if (curInfo === true){
-                Ember.$('#submission-instructions').hide(400);
-            }
-            else {
-                Ember.$('#submission-instructions').show(400);
-            }
-            this.controllerFor('index').set('info', !curInfo);
         }
     }
 });

--- a/app/styles/conference.scss
+++ b/app/styles/conference.scss
@@ -45,6 +45,7 @@
 	background-color: rgba(0,0,0,0.1);
 	padding: 15px;
 	margin-top: 15px;
+  margin-bottom: 15px;
 }
 #submission-instructions
 {

--- a/app/templates/conference/index.hbs
+++ b/app/templates/conference/index.hbs
@@ -35,36 +35,35 @@
                             <div class="row">
                                 <div class="col-md-12">
                                     <div class="btn-group" role="group" aria-label="...">
-                                            <button type="button" class="btn btn-default"
-                                            {{action "toggleInfo"}}>
-                                                Add a submission
-                                                <span class="glyphicon glyphicon-chevron-down"></span>
-                                            </button>
+                                        <button class="btn btn-default" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+                                            Add a submission
+                                            <span class="caret"></span>
+                                        </button>
                                     </div>
                                 </div>
                             </div>
-                            
-                            <div class="row" id="submission-instructions">
-                                <div class="col-md-6">
-                                    <div class="submission-modal">
-                                    <strong>Submit through email</strong>
-                                    <h6>Send an email to your conference identifier with the files you'd like to submit attached to it.</h6>
-                                    <h6>We’ll create an OSF project for you. You'll get a permanent link to your presentation, plus analytics about who has viewed and downloaded your work.</h6>
+                            <div class="collapse" id="collapseExample">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="submission-modal">
+                                            <strong>Submit through email</strong>
+                                            <h6>Send an email to your conference identifier with the files you'd like to submit attached to it.</h6>
+                                            <h6>We’ll create an OSF project for you. You'll get a permanent link to your presentation, plus analytics about who has viewed and downloaded your work.
+                                            </h6>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="btn-group submission-modal" role="group" aria-label="...">
+                                            <strong>Upload Here:</strong>
+                                            <br>
+                                            <h6>You can also use our upload form to submit files</h6>
+                                            {{#link-to "conference.submission" model.conf.id}}
+                                                <button type="button" class="btn btn-success" style="margin: 0 0 5px 0; width: 200px;"><span class="glyphicon glyphicon-plus"></span>  Upload a File</button>
+                                            {{/link-to}}
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="col-md-6">
-                                    <div class="btn-group submission-modal" role="group" aria-label="...">
-                                        <strong>Upload Here:</strong>
-                                        <br>
-                                        <h6>You can also use our upload form to submit files</h6>
-                                        {{#link-to "conference.submission" model.conf.id}}
-                                            <button type="button" class="btn btn-success" style="margin: 0 0 5px 0; width: 200px;"><span class="glyphicon glyphicon-plus"></span>  Upload a File</button>
-                                        {{/link-to}}
-                                    </div>
-                                </div>
-                                
                             </div>
-                            
 
                             <!-- This is the basic code for a table of submissions without images -->
                             {{#if model.conf.submissionCount}}
@@ -89,7 +88,7 @@
                                         </tbody>
                                     </table>
                                 {{/if}}
-                                {{#unless (isEqual model.conf.submissionCount model.conf.mySubmissionCount)}}
+                                {{#unless (eq model.conf.submissionCount model.conf.mySubmissionCount)}}
                                     <h5>Submissions to conference</h5>
                                     <table class="table table-hover">
                                         <thead class="thead">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -84,8 +84,8 @@
         <button id="listButton" class="btn btn-default navbar-btn" {{action "listView"}}>
           <span class="glyphicon glyphicon-th-list"></span>
         </button>
-        <div class="row">
-          <div class="collapse" id="collapseExample">
+        <div class="collapse" id="collapseExample">
+          <div class="row">
             <div class="col-md-6">
               <div class="submission-modal">
                 <h5><strong>Create through email</strong></h5>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,7 +4,7 @@
   <div class="row conference-view-outer-container" id="indexBottom">
     <div class="col-md-10 col-md-offset-1">
       <div class="col-md-10 col-md-offset-1 tile-view fade-background">
-        <button class="btn btn-success navbar-btn" {{action "toggleInfo"}}>
+        <button class="btn btn-success navbar-btn" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
           <span class="glyphicon glyphicon-plus"></span>
           Register a Meeting
         </button>
@@ -14,23 +14,25 @@
         <button id="listButton" class="btn btn-default navbar-btn" {{action "listView"}}>
           <span class="glyphicon glyphicon-th-list"></span>
         </button>
-        <div class="row" id="submission-instructions">
-          <div class="col-md-6">
+        <div class="row">
+          <div class="collapse" id="collapseExample">
+            <div class="col-md-6">
               <div class="submission-modal">
-              <h5><strong>Create through email</strong></h5>
-              <h6>OSF for Meetings is a product that we offer to academic conferences at no cost. To request poster and talk hosting for a conference:</h6>
+                <h5><strong>Create through email</strong></h5>
+                <h6>OSF for Meetings is a product that we offer to academic conferences at no cost. To request poster and talk hosting for a conference:</h6>
 
-              <strong>Email us at <span style="color: blue;">contact@cos.io</span></strong>
+                <strong>Email us at <span style="color: blue;">contact@cos.io</span></strong>
 
-              <h6>We'll review and add your conference within one business day.</h6>
+                <h6>We'll review and add your conference within one business day.</h6>
               </div>
-          </div>
-          <div class="col-md-6">
+            </div>
+            <div class="col-md-6">
               <div class="btn-group submission-modal" role="group" aria-label="...">
                   <h5><strong>Create Here:</strong></h5>
                   <h6>You can also use our conference creation form to set up your meeting here</h6>
                       <button type="button" class="btn btn-success" style="margin: 0 0 5px 0; width: 200px;" {{action "create"}}><span class="glyphicon glyphicon-plus"></span>  Create a Conference</button>
               </div>
+            </div>
           </div>
         </div>
         <div class="row">
@@ -72,9 +74,9 @@
   <div class="row conference-view-outer-container">
     <div class="col-md-10 col-md-offset-1 ">
       <div class="col-md-10 col-md-offset-1 fade-background table-view">
-        <button class="btn btn-success navbar-btn" {{action "toggleInfo"}}>
+        <button class="btn btn-success navbar-btn" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
           <span class="glyphicon glyphicon-plus"></span>
-          Create a Meeting
+          Register a Meeting
         </button>
         <button id="tileButton" class="btn btn-default navbar-btn" {{action "tileView"}}>
           <span class="glyphicon glyphicon-th-large"></span>
@@ -82,23 +84,25 @@
         <button id="listButton" class="btn btn-default navbar-btn" {{action "listView"}}>
           <span class="glyphicon glyphicon-th-list"></span>
         </button>
-        <div class= "row" id="submission-instructions">
-          <div class="col-md-6">
+        <div class="row">
+          <div class="collapse" id="collapseExample">
+            <div class="col-md-6">
               <div class="submission-modal">
-              <h5><strong>Create through email</strong></h5>
-              <h6>OSF for Meetings is a product that we offer to academic conferences at no cost. To request poster and talk hosting for a conference:</h6>
+                <h5><strong>Create through email</strong></h5>
+                <h6>OSF for Meetings is a product that we offer to academic conferences at no cost. To request poster and talk hosting for a conference:</h6>
 
-              <strong>Email us at <span style="color: blue;">contact@cos.io</span></strong>
+                <strong>Email us at <span style="color: blue;">contact@cos.io</span></strong>
 
-              <h6>We'll review and add your conference within one business day.</h6>
+                <h6>We'll review and add your conference within one business day.</h6>
               </div>
-          </div>
-          <div class="col-md-6">
+            </div>
+            <div class="col-md-6">
               <div class="btn-group submission-modal" role="group" aria-label="...">
                   <h5><strong>Create Here:</strong></h5>
                   <h6>You can also use our conference creation form to set up your meeting here</h6>
                       <button type="button" class="btn btn-success" style="margin: 0 0 5px 0; width: 200px;" {{action "create"}}><span class="glyphicon glyphicon-plus"></span>  Create a Conference</button>
               </div>
+            </div>
           </div>
         </div>
         

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -14,8 +14,8 @@
         <button id="listButton" class="btn btn-default navbar-btn" {{action "listView"}}>
           <span class="glyphicon glyphicon-th-list"></span>
         </button>
-        <div class="row">
-          <div class="collapse" id="collapseExample">
+        <div class="collapse" id="collapseExample">
+          <div class="row">
             <div class="col-md-6">
               <div class="submission-modal">
                 <h5><strong>Create through email</strong></h5>


### PR DESCRIPTION
## Purpose

Sometimes, you have to click twice on the "Add a submission" or "Register a meeting" buttons.
## Proposed Solution

Use [bootstrap](http://getbootstrap.com/javascript/#collapse)  `collapse` instead 

![screen shot 2016-09-01 at 5 35 01 pm](https://cloud.githubusercontent.com/assets/11620890/18185199/7aa8b9ba-706a-11e6-918e-554c31bd16a6.png)

![screen shot 2016-09-01 at 5 35 12 pm](https://cloud.githubusercontent.com/assets/11620890/18185212/84f8fc7c-706a-11e6-9423-a0f81751533f.png)
- [x] Use bootstrap to fix issue with  `Add a submission` button
- [x] Use bootstrap to fix issue with  `Register a meeting` button
