### PR TITLE
[WIP] refresh token addition with update of the oauth flow

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,7 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
-  "unused": true
+  "unused": true,
+  "esversion": 6,
+  "asi": true
 }

--- a/app/authenticators/:w
+++ b/app/authenticators/:w
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import ToriiAuthenticator from 'ember-simple-auth/authenticators/torii';
+
+export default ToriiAuthenticator.extend({
+    torii: Ember.inject.servcei
+});

--- a/app/authenticators/osf-oauth2.js
+++ b/app/authenticators/osf-oauth2.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import ToriiAuthenticator from 'ember-simple-auth/authenticators/torii';
+
+export default ToriiAuthenticator.extend({
+    torii: Ember.inject.service('torii'),
+    authenticate(options) {
+        return this._super(options).then((data) => {
+            //needs implementation for getting access_token through our backend
+            //ajax call thus we need a simple endpoint for getting the token
+            //and return us a session-id
+            console.log(data);
+            debugger;
+        });
+    }
+
+});

--- a/app/components/meetings-navbar.js
+++ b/app/components/meetings-navbar.js
@@ -3,11 +3,12 @@ import Ember from 'ember';
 import config from '../config/environment';
 
 export default Ember.Component.extend({
+    session: Ember.inject.service('session'),
     store: Ember.inject.service('store'),
     fixed: true, /* holds status of navbar -> fixed or unfixed <- depending on mobile view or not */
     host: config.providers.osf.host, /* root URL for Osf redirection */
-    authenticated: false, /* authentication status */
-    user: null, /* current user metadata, initially empty */
+    //authenticated: false, /* authentication status */
+    //user: null, /* current user metadata, initially empty */
     showSearch: false, /* holds current view status of search dropdown */
 
         /*
@@ -19,28 +20,28 @@ export default Ember.Component.extend({
         *
         */
 
-    init: function() {
-        this._super(...arguments);
-        var self = this;
-        Ember.$.ajax({
-            url: config.providers.osfMeetings.currentUser,
-            dataType: 'json',
-            contentType: 'text/plain',
-            xhrFields: {
-                withCredentials: true,
-            }
-        }).then(function(loggedIn) {
-            if (!(loggedIn.errors)) {
-                self.set('authenticated', true);
-                self.set('user', loggedIn);
-                self.get('store').pushPayload('user', loggedIn);
-            }
-            else {
-                self.set('authenticated', false);
-                self.set('user', null);
-            }
-        });
-    },
+//    init: function() {
+//        this._super(...arguments);
+//        var self = this;
+//        Ember.$.ajax({
+//            url: config.providers.osfMeetings.currentUser,
+//            dataType: 'json',
+//            contentType: 'text/plain',
+//            xhrFields: {
+//                withCredentials: true,
+//            }
+//        }).then(function(loggedIn) {
+//            if (!(loggedIn.errors)) {
+//                self.set('authenticated', true);
+//                self.set('user', loggedIn);
+//                self.get('store').pushPayload('user', loggedIn);
+//            }
+//            else {
+//                self.set('authenticated', false);
+//                self.set('user', null);
+//            }
+//        });
+//    },
     actions: {
         /*
         *   search()
@@ -58,13 +59,20 @@ export default Ember.Component.extend({
          */
         /*********************************************************/
 
+        authenticateSession: function() {
+            this.get('session').authenticate('authenticator:osf-oauth2', 'osf-oauth2');
+        },
+
+        invalidateSession: function() {
+            this.get('session').invalidate();
+        },
         /*
         *   logout()
         *   sends action to the application level,
         *   subsequently logs out and removes user metadata
         */
-        logout: function() {
-            this.sendAction('logout');},
+//        logout: function() {
+//            this.sendAction('logout');},
         /*********************************************************/
 
         /*
@@ -72,8 +80,8 @@ export default Ember.Component.extend({
         *   sends action to the application level,
         *   subsequently logs in and adds user metadata
         */
-        login: function() {
-            this.sendAction('login');},
+//        login: function() {
+//            this.sendAction('login');},
         /*********************************************************/
         /*
         * unFix()

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -3,13 +3,37 @@ import Ember from 'ember';
 export
 default Ember.Route.extend({
     actions: {
-        logout: function() {
-            this.transitionTo('logout');
-        },
-        login: function() {
-            document.cookie = "redirectURL=" + window.location.href;
-            this.transitionTo('login');
-        },
+//        logout: function() {
+//            this.get('session').close('osf').then(() => {
+//                this.transitionTo('index');
+//            });
+//
+//            //this.transitionTo('logout');
+//        },
+//        login: function(username, password) {
+//            let route = this;
+//            let providerName = 'osf';
+//
+//            //the options to `this.get('torii').open(providerName, options)`
+//            //will be passed to the provider's `open` method.
+//            let options = {
+//                username: username,
+//                password: password
+//            };
+//
+//            this.get('torii').open(providerName, options).then(function(authorization) {
+//                debugger;
+//                //authorization as returned by the provider
+//                route.somethinWithToken(authorization.sessionToken);
+//            });
+//
+//            //document.cookie = "redirectURL=" + window.location.href;
+//            //this.transitionTo('login');
+//        },
+//        accessDenied() {
+//            this.transitionTo('index');
+//        },
+
         filter(params) {
             this.transitionTo('index', {
                 queryParams: {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import UnauthenticatedRoute from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(UnauthenticatedRoute, {
     results: true,
     query: null,
     queryParams: {

--- a/app/templates/components/meetings-navbar.hbs
+++ b/app/templates/components/meetings-navbar.hbs
@@ -3,10 +3,10 @@
         <div class="container">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
                 </button>
                 <span class="visible-xs" data-bind="click : toggleSearch, css: searchCSS">
                     <a class="osf-xs-search pull-right" {{action "toggleSearch"}} style="padding-top: 12px" >
@@ -22,9 +22,9 @@
             </div>
             <div id="navbar" class="navbar-collapse collapse navbar-right">
                 <ul class="nav navbar-nav">
-                    {{#if authenticated}}
-                    <li id="osfNavDashboard"><a href={{host}}>Dashboard</a></li>
-                    <li id="osfNavMyProjects"><a href="{{host}}myprojects/">My Projects</a></li>
+                    {{#if session.isAuthenticated}}
+                        <li id="osfNavDashboard"><a href={{host}}>Dashboard</a></li>
+                        <li id="osfNavMyProjects"><a href="{{host}}myprojects/">My Projects</a></li>
                     {{/if}}
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Browse <span class="caret"></span></a>
@@ -34,72 +34,72 @@
                             <li><a href="{{host}}meetings/">Meetings</a></li>
                         </ul>
                     </li>
-                    {{# unless authenticated}}
-                    <li class="dropdown">
-                        <a href="${domain}support/" >Support</a>
-                    </li>
+                    {{# unless session.isAuthenticated}}
+                        <li class="dropdown">
+                            <a href="${domain}support/" >Support</a>
+                        </li>
                     {{/unless}}
                     <li class="hidden-xs">
                         <a onclick={{action "toggleSearch"}}>
                             <span rel="tooltip" data-placement="bottom" title="Search OSF" class="fa fa-search fa-lg" ></span>
                         </a>
                     </li>
-                    {{#if authenticated }}
-                    {{!-- TODO: Replace display name functionality if possible- for now truncate via CSS at end of label --}}
-                    <li class="dropdown">
-                        <a href="#" class="dropdown-toggle nav-user-dropdown" data-toggle="dropdown" role="button" aria-expanded="false">
-                            <span class="osf-gravatar">
-                                <img src={{user.links.profile_image}} alt="User gravatar">
-                            </span> {{user.attributes.full_name}}
-                            <span class="caret"></span>
-                        </a>
-                        <ul class="dropdown-menu" role="menu">
-                            <li>
-                                <a href="{{host}}profile/"><i class="fa fa-user fa-lg p-r-xs"></i> My Profile</a>
-                            </li>
-                            <li>
-                                <a href="{{host}}support/" ><i class="fa fa-life-ring fa-lg p-r-xs"></i> Support</a>
-                            </li>
-                            <li>
-                                <a href="{{host}}settings/"><i class="fa fa-cog fa-lg p-r-xs"></i> Settings</a>
-                            </li>
-                            <li>
-                                <a onclick={{action 'logout'}}><i class="fa fa-sign-out fa-lg p-r-xs"></i> Log out</a>
-                            </li>
-                        </ul>
-                    </li>
-                    {{else}}
-                    <li class="dropdown sign-in" data-bind="with: $root.signIn">
-                        <div class="btn-group">
-                            <a href="{{host}}register/" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
-                            <a onclick={{action 'login'}} class="btn btn-info btn-top-login">
-                                Sign in <span class="hidden-xs"><i class="fa fa-arrow-right"></i></span>
+                    {{#if session.isAuthenticated }}
+                        {{!-- TODO: Replace display name functionality if possible- for now truncate via CSS at end of label --}}
+                        <li class="dropdown">
+                            <a href="#" class="dropdown-toggle nav-user-dropdown" data-toggle="dropdown" role="button" aria-expanded="false">
+                                <span class="osf-gravatar">
+                                    <img src={{user.links.profile_image}} alt="User gravatar">
+                                </span> {{user.attributes.full_name}}
+                                <span class="caret"></span>
                             </a>
-                        </div>
-                    </li>
+                            <ul class="dropdown-menu" role="menu">
+                                <li>
+                                    <a href="{{host}}profile/"><i class="fa fa-user fa-lg p-r-xs"></i> My Profile</a>
+                                </li>
+                                <li>
+                                    <a href="{{host}}support/" ><i class="fa fa-life-ring fa-lg p-r-xs"></i> Support</a>
+                                </li>
+                                <li>
+                                    <a href="{{host}}settings/"><i class="fa fa-cog fa-lg p-r-xs"></i> Settings</a>
+                                </li>
+                                <li>
+                                    <a onclick={{action 'invalidateSession'}}><i class="fa fa-sign-out fa-lg p-r-xs"></i> Log out</a>
+                                </li>
+                            </ul>
+                        </li>
+                    {{else}}
+                        <li class="dropdown sign-in" data-bind="with: $root.signIn">
+                            <div class="btn-group">
+                                <a href="{{host}}register/" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
+                                <a onclick={{action 'authenticateSession'}} class="btn btn-info btn-top-login">
+                                    Sign in <span class="hidden-xs"><i class="fa fa-arrow-right"></i></span>
+                                </a>
+                            </div>
+                        </li>
                     {{/if}}
                 </ul>
             </div>{{!--/.navbar-collapse --}}
         </div>
     </nav>
     {{#if showSearch}}
-    <div class="osf-search">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12">
-                    <form class="input-group" {{action "search" on="submit"}}>
-                        {{input value=searchQuery id="searchPageFullBar"
-                        name="search-placeholder" type="text" class="osf-search-input form-control" placeholder="Search" key-up="filter"}}
-                        <label id="searchBarLabel" class="search-label-placeholder" for="search-placeholder">Search</label>
-                        <span class="input-group-btn">
-                            <button  class="btn osf-search-btn"{{action "search"}}><i class="fa fa-arrow-circle-right fa-lg"></i></button>
-                            <button type="button" class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
-                            <button type="button" class="btn osf-search-btn" onclick={{action "toggleSearch"}}><i class="fa fa-times fa-lg"></i></button>
-                        </span>
-                    </form>
+        <div class="osf-search">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12">
+                        <form class="input-group" {{action "search" on="submit"}}>
+                            {{input value=searchQuery id="searchPageFullBar"
+                            name="search-placeholder" type="text" class="osf-search-input form-control" placeholder="Search" key-up="filter"}}
+                            <label id="searchBarLabel" class="search-label-placeholder" for="search-placeholder">Search</label>
+                            <span class="input-group-btn">
+                                <button  class="btn osf-search-btn"{{action "search"}}><i class="fa fa-arrow-circle-right fa-lg"></i></button>
+                                <button type="button" class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
+                                <button type="button" class="btn osf-search-btn" onclick={{action "toggleSearch"}}><i class="fa fa-times fa-lg"></i></button>
+                            </span>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
     {{/if}}
 </div>

--- a/app/torii-providers/osf-oauth2.js
+++ b/app/torii-providers/osf-oauth2.js
@@ -1,0 +1,21 @@
+import OAuth2 from 'torii/providers/oauth2-code';
+import {configurable} from 'torii/configuration';
+
+export default OAuth2.extend({
+    // Create a new authorization.
+    // When your code calls `this.get('torii').open('geocities', options)`,
+    // the `options` will be passed to this provider's `open` method.
+
+    name: 'osf-oauth2',
+    baseUrl: configurable('baseUrl'),
+
+    redirectUri: configurable('redirectUrl'),
+    state: 'STATE',
+
+    //response params that we expect to be returned
+    responseParams: ['code'],
+
+    fetch(data) {
+        return data;
+    }
+});

--- a/config/environment.js
+++ b/config/environment.js
@@ -18,6 +18,21 @@ module.exports = function(environment) {
             routeAfterAuthentication: 'index'
         },
 
+        torii: {
+            providers: {
+                "osf-oauth2": {
+                    "baseUrl": "https://staging-accounts.osf.io/oauth2/authorize",
+                    "responseType": "code",
+                    "clientId": "b32175579c7a4273ac663293a1c20d21",
+                    "redirectUrl": "http://localhost:4200/callback/",
+                    "scope": "osf.full_write",
+                    //"accessType": "online",
+                    //"approvalPrompt": "online"
+                }
+            }
+        },
+
+
         APP: {
             // Here you can pass flags/options to your application instance
             // when it is created
@@ -44,7 +59,7 @@ module.exports = function(environment) {
                 "uploadsUrl": "https://staging-files.osf.io/v1/resources/",
                 "uploadMultiple": false
             }
-        }
+        };
     }
 
     if (environment === 'test') {

--- a/meetings/meetings/settings/defaults.py
+++ b/meetings/meetings/settings/defaults.py
@@ -180,17 +180,6 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:4200',
 )
 
-CORS_ALLOW_HEADERS = (
-    'x-requested-with',
-    'content-type',
-    'accept',
-    'origin',
-    'authorization',
-    'x-csrftoken',
-    'cache-control',
-)
-
-
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "0.3.3",
     "ember-scroll-to": "0.5.1",
+    "ember-simple-auth": "1.1.0",
     "ember-toastr": "1.4.1",
     "ember-truth-helpers": "1.2.0",
     "ember-validations": "2.0.0-alpha.4",
@@ -70,6 +71,7 @@
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
     "svg4everybody": "2.0.3",
+    "torii": "0.8.0",
     "wormhole": "3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
- [x] access code request with ember with a popup window 
- [ ] access token request through our API
- [ ] session-id response (still doing research if we need this)
- [ ] remove old authentication flow
- [ ] refresh-token request 

Currently ember-osf has an implementation of login in however since we have our own API we shouldn't be doing an `implicit grant`, but rather a `authorization code grant`flow. Thus we need to implement our own oauth flow.

This uses Ember-Simple-Auth with Torii provider.
Info on this if someone wants to learn more about this.
https://vimeo.com/146851881
